### PR TITLE
Latest dependencies

### DIFF
--- a/IpfsMount.nuspec
+++ b/IpfsMount.nuspec
@@ -21,7 +21,7 @@ See the [README](https://github.com/richardschneider/net-ipfs-mount) for details
 ## Quick start
 
     > ipfs-mount z 
-    > dir z:\ipfs\QmRCJXG7HSmprrYwDrK1GctXHgbV7EYpVcJPQPwevoQuqF /B/S
+    > dir z:\ipfs\QmRCJXG7HSmprrYwDrK1GctXHgbV7EYpVcJPQPwevoQuqF /B/S 
 
 ````
 z:\ipfs\QmRCJXG7HSmprrYwDrK1GctXHgbV7EYpVcJPQPwevoQuqF\cat.jpg

--- a/IpfsMount/IpfsMount.csproj
+++ b/IpfsMount/IpfsMount.csproj
@@ -58,8 +58,8 @@
     <Reference Include="Ipfs.Api, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Ipfs.Api.0.17.0\lib\net45\Ipfs.Api.dll</HintPath>
     </Reference>
-    <Reference Include="Ipfs.Core, Version=0.19.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Ipfs.Core.0.19.1\lib\net45\Ipfs.Core.dll</HintPath>
+    <Reference Include="Ipfs.Core, Version=0.19.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ipfs.Core.0.19.2\lib\net45\Ipfs.Core.dll</HintPath>
     </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
@@ -67,12 +67,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="SHA3, Version=0.9.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SHA3.0.9.2\lib\net40\SHA3.dll</HintPath>
-    </Reference>
-    <Reference Include="SHA3Managed, Version=0.9.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SHA3.0.9.2\lib\net40\SHA3Managed.dll</HintPath>
     </Reference>
     <Reference Include="SimpleBase, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleBase.1.3.1\lib\net45\SimpleBase.dll</HintPath>

--- a/IpfsMount/IpfsMount.csproj
+++ b/IpfsMount/IpfsMount.csproj
@@ -55,11 +55,11 @@
     <Reference Include="Google.Protobuf, Version=3.4.1.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Protobuf.3.4.1\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
-    <Reference Include="Ipfs.Api, Version=0.14.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Ipfs.Api.0.14.0\lib\net45\Ipfs.Api.dll</HintPath>
+    <Reference Include="Ipfs.Api, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ipfs.Api.0.17.0\lib\net45\Ipfs.Api.dll</HintPath>
     </Reference>
-    <Reference Include="Ipfs.Core, Version=0.14.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Ipfs.Core.0.14.0\lib\net45\Ipfs.Core.dll</HintPath>
+    <Reference Include="Ipfs.Core, Version=0.19.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ipfs.Core.0.19.1\lib\net45\Ipfs.Core.dll</HintPath>
     </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>

--- a/IpfsMount/packages.config
+++ b/IpfsMount/packages.config
@@ -6,8 +6,8 @@
   <package id="DokanNet" version="1.1.0.1" targetFramework="net452" />
   <package id="Fody" version="2.2.0" targetFramework="net452" developmentDependency="true" />
   <package id="Google.Protobuf" version="3.4.1" targetFramework="net452" />
-  <package id="Ipfs.Api" version="0.14.0" targetFramework="net452" />
-  <package id="Ipfs.Core" version="0.14.0" targetFramework="net452" />
+  <package id="Ipfs.Api" version="0.17.0" targetFramework="net452" />
+  <package id="Ipfs.Core" version="0.19.2" targetFramework="net452" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net452" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />


### PR DESCRIPTION
Use the latest version of Ipfs.Api and Ipfs.Core, #2.